### PR TITLE
update LuaDocs with ProfileSortType

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -2699,6 +2699,12 @@
 			<EnumValue name='&apos;ProfileSlot_Player2&apos;' value='1'/>
 			<EnumValue name='&apos;ProfileSlot_Machine&apos;' value='2'/>
 		</Enum>
+		<Enum name='ProfileSortType'>
+			<EnumValue name='&apos;	ProfileSortType_Priority,&apos;' value='0'/>
+			<EnumValue name='&apos;	ProfileSortType_Recent,&apos;' value='1'/>
+			<EnumValue name='&apos;	ProfileSortType_Alphabetical,&apos;' value='2'/>
+			<EnumValue name='&apos;	ProfileSortType_Alphabetical_DESC,&apos;' value='3'/>
+		</Enum>
 		<Enum name='ProfileType'>
 			<EnumValue name='&apos;ProfileType_Guest&apos;' value='0'/>
 			<EnumValue name='&apos;ProfileType_Normal&apos;' value='1'/>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -4747,7 +4747,8 @@ prev_note_name, succeeded = options:NoteSkin("cel")
 		Returns the number of trails with the specified StepsType and Difficulty that you've scored a certain Grade <code>g</code> on.
 	</Function>
 	<Function name='GetType' return='ProfileType' arguments=''>
-		Returns the type of the profile.  The type of the profile is only used to determine where the profile shows up in the list of profiles, and that problem is already handled by ProfileManager, so if you're reading this, this function only exists so you can make your theme color this profile's list entry based on the type or something like that.
+		Returns the type of the profile.  A profile's type is used by the StepMania engine to sort the list of profiles when
+		the <code>ProfileSortType</code> preference is set to <Link class='ENUM' function='ProfileSortType'>Priority</Link>.
 	</Function>
 	<Function name='GetUserTable' return='table' arguments=''>
 		Returns the user table for this Profile.
@@ -6856,6 +6857,13 @@ end
 <Enum name='HorizAlign'>
 	<Description>
 		Horizontal alignment. See <Link class='Actor' function='horizalign' />.
+	</Description>
+</Enum>
+<Enum name='ProfileSortType'>
+	<Description>
+		Possible values for the <code>ProfileSortType</code> preference.  These determine how the list of profiles is sorted.<br />
+		<code>Priority</code> uses profile <Link class='ENUM' function='ProfileType' /> to show <code>Guest</code> profiles first, then <code>Normal</code>, then <code>Test</code>.<br />
+		<code>Recent</code> sorts profiles in the order they are used, with the most recently used profile appearing first.
 	</Description>
 </Enum>
 <Enum name='VertAlign'>


### PR DESCRIPTION
This ensures ITGMania's LuaDocs reflect the changes in your PR.

As an aside, do you think `ProfileSortType` should be renamed to `ProfileSortOrder` to more closely align with existing code in StepMania's src?  (i.e. `SortOrder` and `CourseSortOrder` are other enums that already exist)