### PR TITLE
Fixportalbehavior fixes

### DIFF
--- a/src/GameConstantsAndTypes.h
+++ b/src/GameConstantsAndTypes.h
@@ -192,7 +192,7 @@ enum SortOrder
 	SORT_ONI_COURSES, /**< View only the oni/survival courses. */
 	SORT_ENDLESS_COURSES, /**< View only the endless courses. */
 	SORT_LENGTH, /**< Sort the songs/courses by how long they would last. */
-	SORT_ROULETTE,
+	SORT_ROULETTE, // Note: don't call more than once per line as successive calls can clear the vector used. TODO: fix this underlying bug.
 	SORT_RECENT,
 	SORT_RECENT_P1, /**< Sort by the most recent play for P1. */
 	SORT_RECENT_P2, /**< Sort by the most recent play for P2. */

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -1483,9 +1483,8 @@ void MusicWheel::StartRoulette()
 	m_Moving = 1;
 	m_TimeBeforeMovingBegins = 0;
 	m_SpinSpeed = 1.0f/ROULETTE_SWITCH_SECONDS;
-	RandomGen rnd;
 	auto &rouletteItems = getWheelItemsData(SORT_ROULETTE);
-	std::shuffle( rouletteItems.begin(), rouletteItems.end(), rnd );
+	std::shuffle( rouletteItems.begin(), rouletteItems.end(), g_RandomNumberGenerator );
 	GAMESTATE->m_SortOrder.Set( SORT_ROULETTE );
 	//SetOpenSection( m_sExpandedSectionName );
 	RebuildWheelItems();
@@ -1500,9 +1499,8 @@ void MusicWheel::StartRandom()
 	if( RANDOM_PICKS_LOCKED_SONGS )
 	{
 		// Shuffle and use the roulette wheel.
-		RandomGen rnd;
 		auto &rouletteItems = getWheelItemsData(SORT_ROULETTE);
-		std::shuffle( rouletteItems.begin(), rouletteItems.end(), rnd );
+		std::shuffle( rouletteItems.begin(), rouletteItems.end(), g_RandomNumberGenerator );
 		GAMESTATE->m_SortOrder.Set( SORT_ROULETTE );
 	}
 	else

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -1484,7 +1484,8 @@ void MusicWheel::StartRoulette()
 	m_TimeBeforeMovingBegins = 0;
 	m_SpinSpeed = 1.0f/ROULETTE_SWITCH_SECONDS;
 	RandomGen rnd;
-	std::shuffle( getWheelItemsData(SORT_ROULETTE).begin(), getWheelItemsData(SORT_ROULETTE).end(), rnd );
+	auto &rouletteItems = getWheelItemsData(SORT_ROULETTE);
+	std::shuffle( rouletteItems.begin(), rouletteItems.end(), rnd );
 	GAMESTATE->m_SortOrder.Set( SORT_ROULETTE );
 	//SetOpenSection( m_sExpandedSectionName );
 	RebuildWheelItems();
@@ -1500,7 +1501,8 @@ void MusicWheel::StartRandom()
 	{
 		// Shuffle and use the roulette wheel.
 		RandomGen rnd;
-		std::shuffle( getWheelItemsData(SORT_ROULETTE).begin(), getWheelItemsData(SORT_ROULETTE).end(), rnd );
+		auto &rouletteItems = getWheelItemsData(SORT_ROULETTE);
+		std::shuffle( rouletteItems.begin(), rouletteItems.end(), rnd );
 		GAMESTATE->m_SortOrder.Set( SORT_ROULETTE );
 	}
 	else


### PR DESCRIPTION
I observed a few issues here and took care of them.  This seems to resolve the poor entropy issue.  I am seeing good randomness with this change.


Please see the comments associated with each commit for further context. It seems that some unwanted/undefined behavior could be avoided by ensuring SORT_ROULETTE is only called once for the 

It would be good to fix the root issue, but I would want to take care of that after 1.2.0 since the release date is getting close by. For this reason I left a TODO at the SORT_ROULETTE definition.